### PR TITLE
Market model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
   gem 'hirb'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem "capybara"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -18,10 +18,8 @@ gem "jsonapi-serializer"
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 
-#ruby geocoder gem 
-gem 'geocoder', '~> 1.3', '>= 1.3.7'
-
-# gem 'activerecord-postgis-adapter'
+#rails geokit
+gem 'geokit-rails'
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,10 @@ GEM
       railties (>= 5.0.0)
     faker (3.2.0)
       i18n (>= 1.8.11, < 2)
-    geocoder (1.8.2)
+    geokit (1.14.0)
+    geokit-rails (2.5.0)
+      geokit (~> 1.5)
+      rails (>= 3.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     hirb (0.7.3)
@@ -226,7 +229,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
-  geocoder (~> 1.3, >= 1.3.7)
+  geokit-rails
   hirb
   jsonapi-serializer
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,9 +66,20 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    capybara (3.39.2)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -106,6 +117,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.18.1)
@@ -128,6 +140,7 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (5.0.3)
     puma (5.6.6)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -163,6 +176,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    regexp_parser (2.8.1)
     reline (0.3.6)
       io-console (~> 0.5)
     rspec-core (3.12.2)
@@ -197,14 +211,18 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.6.9)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
   bootsnap
+  capybara
   debug
   factory_bot_rails
   faker

--- a/app/controllers/api/v1/markets_controller.rb
+++ b/app/controllers/api/v1/markets_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::MarketsController < ApplicationController
+  def index
+    markets = Market.all
+    render json: MarketSerializer.format_markets(markets)
+  end
+end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -1,4 +1,4 @@
 class Market < ApplicationRecord
-  reverse_geocoded_by :longitude, :latitude
-  after_validation :reverse_geocode
+  geocoded_by :address
+  after_validation :geocode
 end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -1,6 +1,6 @@
 class Market < ApplicationRecord
-  geocoded_by :address
-  after_validation :geocode
+  acts_as_mappable  lat_column_name: :latitude,
+                    lng_column_name: :longitude
 
   def self.accepts_benefits
     where('fnap IS NOT NULL OR snap_option IS NOT NULL')
@@ -14,7 +14,7 @@ class Market < ApplicationRecord
     where('fnap IS NOT NULL')
   end
 
-  def self.closest_markets(coordinates, radius)
-    require 'pry'; binding.pry
+  def self.nearby_markets(coordinates, radius)
+    within(radius, origin: coordinates)
   end
 end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -1,4 +1,20 @@
 class Market < ApplicationRecord
   geocoded_by :address
   after_validation :geocode
+
+  def self.accepts_benefits
+    where('fnap IS NOT NULL OR snap_option IS NOT NULL')
+  end
+
+  def self.snap_available
+    where('snap_option IS NOT NULL')
+  end
+
+  def self.fnap_available
+    where('fnap IS NOT NULL')
+  end
+
+  def self.closest_markets(coordinates, radius)
+    require 'pry'; binding.pry
+  end
 end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -1,4 +1,4 @@
 class Market < ApplicationRecord
-  geocoded_by [:longitute, :latitude]
-  after_validation :geocode
+  reverse_geocoded_by :longitude, :latitude
+  after_validation :reverse_geocode
 end

--- a/app/serializers/market_serializer.rb
+++ b/app/serializers/market_serializer.rb
@@ -1,0 +1,25 @@
+class MarketSerializer
+  include JSONAPI::Serializer
+  attributes :name, :address, :site, :description, :fnap, :snap_option, :accepted_payment, :longitute, :latitude
+
+  def self.format_markets(markets)
+    {
+      data: markets.map do |market|
+        {
+          id: market.id,
+          attributes: {
+            name: market.name,
+            address: market.address,
+            site: market.site,
+            description: market.description,
+            fnap: market.fnap,
+            snap_option: market.snap_option,
+            accepted_payment: market.accepted_payment,
+            longitude: market.longitude,
+            latitude: market.longitude
+          }
+        }
+      end
+    }
+  end
+end

--- a/config/initializers/geokit_config.rb
+++ b/config/initializers/geokit_config.rb
@@ -1,0 +1,100 @@
+# These defaults are used in Geokit::Mappable.distance_to and acts_as_mappable
+Geokit::default_units = :miles # others :kms, :nms, :meters
+Geokit::default_formula = :sphere
+
+# This is the timeout value in seconds to be used for calls to the geocoder web
+# services.  For no timeout at all, comment out the setting.  The timeout unit
+# is in seconds.
+Geokit::Geocoders::request_timeout = 3
+
+# This setting can be used if web service calls must be routed through a proxy.
+# These setting can be nil if not needed, otherwise, a valid URI must be
+# filled in at a minimum.  If the proxy requires authentication, the username
+# and password can be provided as well.
+# Geokit::Geocoders::proxy = 'https://user:password@host:port'
+
+# This is your yahoo application key for the Yahoo Geocoder.
+# See http://developer.yahoo.com/faq/index.html#appid
+# and http://developer.yahoo.com/maps/rest/V1/geocode.html
+# Geokit::Geocoders::YahooGeocoder.key = 'REPLACE_WITH_YOUR_YAHOO_KEY'
+# Geokit::Geocoders::YahooGeocoder.secret = 'REPLACE_WITH_YOUR_YAHOO_SECRET'
+
+# This is your Google Maps geocoder keys (all optional).
+# See http://www.google.com/apis/maps/signup.html
+# and http://www.google.com/apis/maps/documentation/#Geocoding_Examples
+# Geokit::Geocoders::GoogleGeocoder.client_id = ''
+# Geokit::Geocoders::GoogleGeocoder.cryptographic_key = ''
+# Geokit::Geocoders::GoogleGeocoder.channel = ''
+
+# You can also use the free API key instead of signed requests
+# See https://developers.google.com/maps/documentation/geocoding/#api_key
+# Geokit::Geocoders::GoogleGeocoder.api_key = ''
+
+# You can also set multiple API KEYS for different domains that may be directed
+# to this same application.
+# The domain from which the current user is being directed will automatically
+# be updated for Geokit via
+# the GeocoderControl class, which gets it's begin filter mixed
+# into the ActionController.
+# You define these keys with a Hash as follows:
+# Geokit::Geocoders::google = {
+# 'rubyonrails.org' => 'RUBY_ON_RAILS_API_KEY',
+# ' ruby-docs.org' => 'RUBY_DOCS_API_KEY' }
+
+# This is your username and password for geocoder.us.
+# To use the free service, the value can be set to nil or false.  For
+# usage tied to an account, the value should be set to username:password.
+# See http://geocoder.us
+# and http://geocoder.us/user/signup
+# Geokit::Geocoders::UsGeocoder.key = 'username:password'
+
+# This is your authorization key for geocoder.ca.
+# To use the free service, the value can be set to nil or false.  For
+# usage tied to an account, set the value to the key obtained from
+# Geocoder.ca.
+# See http://geocoder.ca
+# and http://geocoder.ca/?register=1
+# Geokit::Geocoders::CaGeocoder.key = 'KEY'
+
+# This is your username key for geonames.
+# To use this service either free or premium, you must register a key.
+# See http://www.geonames.org
+# Geokit::Geocoders::GeonamesGeocoder.key = 'KEY'
+
+# Most other geocoders need either no setup or a key
+# Geokit::Geocoders::BingGeocoder.key = ''
+# Geokit::Geocoders::MapQuestGeocoder.key = ''
+# Geokit::Geocoders::YandexGeocoder.key = ''
+# Geokit::Geocoders::MapboxGeocoder.key = 'ACCESS_TOKEN'
+# Geokit::Geocoders::OpencageGeocoder.key = 'some_api_key'
+
+# Geonames has a free service and a premium service, each using a different URL
+# GeonamesGeocoder.premium = true will use http://ws.geonames.net (premium)
+# GeonamesGeocoder.premium = false will use http://api.geonames.org (free)
+# Geokit::Geocoders::GeonamesGeocoder.premium = false
+
+# require "external_geocoder.rb"
+# Please see the section "writing your own geocoders" for more information.
+# Geokit::Geocoders::external_key = 'REPLACE_WITH_YOUR_API_KEY'
+
+# This is the order in which the geocoders are called in a failover scenario
+# If you only want to use a single geocoder, put a single symbol in the array.
+# Valid symbols are :google, :yahoo, :us, and :ca.
+# Be aware that there are Terms of Use restrictions on how you can use the
+# various geocoders.  Make sure you read up on relevant Terms of Use for each
+# geocoder you are going to use.
+# Geokit::Geocoders::provider_order = [:google,:us]
+
+# The IP provider order. Valid symbols are :ip,:geo_plugin.
+# As before, make sure you read up on relevant Terms of Use for each.
+# Geokit::Geocoders::ip_provider_order = [:external,:geo_plugin,:ip]
+
+# Disable HTTPS globally.  This option can also be set on individual
+# geocoder classes.
+# Geokit::Geocoders::secure = false
+
+# Control verification of the server certificate for geocoders using HTTPS
+# Geokit::Geocoders::ssl_verify_mode = OpenSSL::SSL::VERIFY_(PEER/NONE)
+# Setting this to VERIFY_NONE may be needed on systems that don't have
+# a complete or up to date root certificate store. Only applies to
+# the Net::HTTP adapter.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,9 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  namespace :api do 
+    namespace :v1 do 
+      resources :markets, only: [:index]
+    end
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,5 +27,4 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_26_175513) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,4 +27,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_26_175513) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     name { Faker::Name.first_name }
     address { addresses.sample }
     site { Faker::Address.community }
-    description { Faker::MichaelScott.quote }
+    description { Faker::TvShows::MichaelScott.quote }
     fnap {Faker::Dessert.flavor }
     snap_option { Faker::Food.dish }
     accepted_payment { Faker::Currency.name }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,11 +17,5 @@ FactoryBot.define do
     fnap {Faker::Dessert.flavor }
     snap_option { Faker::Food.dish }
     accepted_payment { Faker::Currency.name }
-    longitude { -104.0000000 }
-    latitude { 42.0000000 }
-  end
-
-  after(:create) do 
-    geocode_by [:latitude, :longitude]
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -13,11 +13,15 @@ FactoryBot.define do
     name { Faker::Name.first_name }
     address { addresses.sample }
     site { Faker::Address.community }
-    description { Faker::MichaelScott.quote }
+    description { Faker::Quote.famous_last_words }
     fnap {Faker::Dessert.flavor }
     snap_option { Faker::Food.dish }
     accepted_payment { Faker::Currency.name }
-    longitude {-104.0000000 }
+    longitude { -104.0000000 }
     latitude { 42.0000000 }
+  end
+
+  after(:create) do 
+    geocode_by [:latitude, :longitude]
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,37 +1,23 @@
-# FactoryBot.define do 
-#   factory :markets do 
-#     name {Faker::}
+addresses = [
+  "501 Foster Street, Durham, North Carolina 27701", 
+  "15500 County Road 6, Plymouth, Minnesota 55447", 
+  "7350 Pine Creek Road, Colorado Springs, Colorado 80919", 
+  "Main Street & Church Street, Granville, NY, USA", 
+  "3939 Granger Road, Medina, OH, USA", 
+  "2441 Foothill Blvd., Rock Springs, WY, 82901", 
+  "50 Upper Alabama Street, Atlanta, GA, USA"
+  ]
 
-#   end
-
-#   factory :invoice_item do 
-#     :invoice
-#     :item
-#     quantity {Faker::Number.within(range: 1..10)}
-#     unit_price {Faker::Number.decimal(l_digits: 2)}
-#   end
-
-#   factory :invoice do
-#     status {"completed"}
-#     :merchant
-#     :customer
-#   end
-  
-#   factory :item do
-#     name {Faker::Coffee.variety}
-#     description {Faker::Quote.famous_last_words}
-#     unit_price {Faker::Number.decimal(l_digits: 2)}
-#     :merchant
-#   end
-
-#   factory :merchant do
-#     name {Faker::FunnyName.two_word_name}
-#   end
-
-#   factory :transaction do
-#     result { "successful"}
-#     credit_card_number {Faker::Finance.credit_card}
-#     credit_card_expiration_date {Faker::Business.credit_card_expiry_date}
-#     :invoice
-#   end
-# end
+FactoryBot.define do 
+  factory :market do 
+    name { Faker::Name.first_name }
+    address { addresses.sample }
+    site { Faker::Address.community }
+    description { Faker::MichaelScott.quote }
+    fnap {Faker::Dessert.flavor }
+    snap_option { Faker::Food.dish }
+    accepted_payment { Faker::Currency.name }
+    longitude {-104.0000000 }
+    latitude { 42.0000000 }
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,5 +17,7 @@ FactoryBot.define do
     fnap {Faker::Dessert.flavor }
     snap_option { Faker::Food.dish }
     accepted_payment { Faker::Currency.name }
+    latitude { -104.7890345 }
+    longitude { 40.7698435 }
   end
 end

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -8,4 +8,37 @@ RSpec.describe Market, type: :model do
       expect(market.valid?).to be true
     end
   end
+
+  describe 'class methods' do 
+    before(:each) do 
+      addresses = [
+        "501 Foster Street, Durham, North Carolina 27701", 
+        "15500 County Road 6, Plymouth, Minnesota 55447", 
+        "7350 Pine Creek Road, Colorado Springs, Colorado 80919", 
+        "Main Street & Church Street, Granville, NY, USA", 
+        "3939 Granger Road, Medina, OH, USA", 
+        "2441 Foothill Blvd., Rock Springs, WY, 82901", 
+        "50 Upper Alabama Street, Atlanta, GA, USA"
+        ]
+      10.times do 
+        Market.create!({
+          name: Faker::Name.first_name, 
+          address: addresses.sample, 
+          site: Faker::Address.community,  
+          description: Faker::Quote.famous_last_words,  
+          fnap: Faker::Dessert.flavor, 
+          snap_option: Faker::Food.dish, 
+          accepted_payment: Faker::Currency.name
+        })
+      end
+      create(:market, fnap: 'accepts')
+      create(:market, snap_option: 'accepts')
+      create(:market, snap_option: 'accepts', fnap: 'accepts')
+      create_list(:market, 5)
+    end
+
+    it '#accepts_benefits' do 
+require 'pry'; binding.pry
+    end
+  end
 end

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Market, type: :model do
-  
   describe 'validations' do 
     it 'geocodes market upon validation' do
       market = Market.new(longitude: 12.34, latitude: 56.78)

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -10,24 +10,41 @@ RSpec.describe Market, type: :model do
   end
 
   describe 'class methods' do 
-    before(:each) do 
-      create(:market, fnap: 'accepts')
-      create(:market, fnap: nil)
-      create(:market, snap_option: nil)
-      create(:market, fnap: nil, snap_option: nil)
-      create(:market, fnap: nil, snap_option: nil)
-      create(:market, snap_option: 'accepts')
-      create(:market, snap_option: 'accepts', fnap: 'accepts')
-      create(:market, snap_option: 'accepts', fnap: 'accepts')
-      create_list(:market, 5)
+    describe 'benefits' do 
+      before(:each) do 
+        create(:market, fnap: nil)
+        create(:market, snap_option: nil)
+        create(:market, fnap: nil, snap_option: nil)
+        create(:market, fnap: nil, snap_option: nil)
+        create(:market, snap_option: 'accepts')
+        create(:market, snap_option: 'accepts', fnap: 'accepts')
+      end
+
+      it '::accepts_benefits' do 
+        result = Market.accepts_benefits
+        expect(result.count).to eq(4) 
+      end
+
+      it '::snap_available' do 
+        result = Market.snap_available
+        expect(result.count).to eq(3)
+      end
+
+      it '::fnap_available' do 
+        result = Market.fnap_available
+        expect(result.count).to eq(3)
+      end
     end
 
-    it '#accepts_any_benefits' do 
+    describe 'proximity' do 
+    it '::closest_markets' do 
+      create(:market, address: "501 Foster Street, Durham, North Carolina 27701")
+      create(:market, address: "7350 Pine Creek Road, Colorado Springs, Colorado 80919")
+      create(:market, address: "2441 Foothill Blvd., Rock Springs, WY, 82901")
+      create(:market, address: "3939 Granger Road, Medina, OH, USA")
+      result = Market.closest_markets([-104.8970453, 40.7893642], 100)
       require 'pry'; binding.pry
     end
-
-    it '#accepts_snap_benefits' do 
-      
-    end
+  end
   end
 end

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -1,13 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Market, type: :model do
-  describe 'validations' do 
-    it 'geocodes market upon validation' do
-      market = Market.new(longitude: 12.34, latitude: 56.78)
-      expect(market).to receive(:geocode)
-      expect(market.valid?).to be true
-    end
-  end
+  describe 'validations' 
 
   describe 'class methods' do 
     describe 'benefits' do 
@@ -37,14 +31,15 @@ RSpec.describe Market, type: :model do
     end
 
     describe 'proximity' do 
-    it '::closest_markets' do 
-      create(:market, address: "501 Foster Street, Durham, North Carolina 27701")
-      create(:market, address: "7350 Pine Creek Road, Colorado Springs, Colorado 80919")
-      create(:market, address: "2441 Foothill Blvd., Rock Springs, WY, 82901")
-      create(:market, address: "3939 Granger Road, Medina, OH, USA")
-      result = Market.closest_markets([-104.8970453, 40.7893642], 100)
-      require 'pry'; binding.pry
+      it '::nearby_markets' do 
+        market_1 = create(:market, longitude: -81.1478018, latitude: 36.1582212)
+        market_2 = create(:market, longitude: -81.2843197, latitude: 35.6741832)
+        market_3 = create(:market, longitude: -117.90522, latitude: 48.543279)
+        market_4 = create(:market, longitude: -80.3862664534582, latitude: 33.97372952277976)
+        market_5 = create(:market, longitude: -73.686043, latitude: 40.983895)
+        result = Market.nearby_markets([34.60, -80.34], 50)
+        expect(result.to_a).to eq([market_4])
+      end
     end
-  end
   end
 end

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -11,34 +11,23 @@ RSpec.describe Market, type: :model do
 
   describe 'class methods' do 
     before(:each) do 
-      addresses = [
-        "501 Foster Street, Durham, North Carolina 27701", 
-        "15500 County Road 6, Plymouth, Minnesota 55447", 
-        "7350 Pine Creek Road, Colorado Springs, Colorado 80919", 
-        "Main Street & Church Street, Granville, NY, USA", 
-        "3939 Granger Road, Medina, OH, USA", 
-        "2441 Foothill Blvd., Rock Springs, WY, 82901", 
-        "50 Upper Alabama Street, Atlanta, GA, USA"
-        ]
-      10.times do 
-        Market.create!({
-          name: Faker::Name.first_name, 
-          address: addresses.sample, 
-          site: Faker::Address.community,  
-          description: Faker::Quote.famous_last_words,  
-          fnap: Faker::Dessert.flavor, 
-          snap_option: Faker::Food.dish, 
-          accepted_payment: Faker::Currency.name
-        })
-      end
       create(:market, fnap: 'accepts')
+      create(:market, fnap: nil)
+      create(:market, snap_option: nil)
+      create(:market, fnap: nil, snap_option: nil)
+      create(:market, fnap: nil, snap_option: nil)
       create(:market, snap_option: 'accepts')
+      create(:market, snap_option: 'accepts', fnap: 'accepts')
       create(:market, snap_option: 'accepts', fnap: 'accepts')
       create_list(:market, 5)
     end
 
-    it '#accepts_benefits' do 
-require 'pry'; binding.pry
+    it '#accepts_any_benefits' do 
+      require 'pry'; binding.pry
+    end
+
+    it '#accepts_snap_benefits' do 
+      
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,6 +66,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
 end
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|

--- a/spec/requests/api/v1/markets/find_spec.rb
+++ b/spec/requests/api/v1/markets/find_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Markets', type: :feature do
+  before(:each) do
+    # 5.times do 
+    #   Market.create!({
+    #     name: "Underground Atlanta Farmers Market ",
+    #     address: "50 Upper Alabama Street, Atlanta, GA, USA",
+    #     site: "Privately owned street on historic property in downtown Atlanta",
+    #     fnap: "Accept EBT at a central location;;",
+    #     snap_option: "Accept EBT at a central location;;",
+    #     accepted_payment: "Cash;Debit card/Credit card;", 
+    #     longitude: -84.3918612,
+    #     latitude: -33.7532152
+    #   })
+    # end
+  end
+
+  describe 'find by long, lat & radius' do
+    # it 'hits the endpoint' do 
+    #   query_params = {
+    #     longitude: -104.0000000, 
+    #     latitude: 42.0000000, 
+    #     radius: 50
+    #   }
+
+    #   get '/api/v1/markets/closest', params: query_params
+
+    #   expect(response).to be_successful
+    # end
+  end
+end

--- a/spec/requests/api/v1/markets/index_spec.rb
+++ b/spec/requests/api/v1/markets/index_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'Market Index', type: :feature do
+  before(:each) do
+
+  end
+
+  describe 'endpoint' do
+    it 'returns all markets' do 
+      get api_v1_markets_path
+
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/requests/api/v1/markets/index_spec.rb
+++ b/spec/requests/api/v1/markets/index_spec.rb
@@ -1,14 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe 'Market Index', type: :feature do
-  before(:each) do
-
-  end
-
+RSpec.describe 'Market Index' do
+  
   describe 'endpoint' do
     it 'returns all markets' do 
+      create_list(:market, 5)
       get api_v1_markets_path
-
       expect(response).to be_successful
     end
   end

--- a/spec/requests/api/v1/markets/index_spec.rb
+++ b/spec/requests/api/v1/markets/index_spec.rb
@@ -7,6 +7,40 @@ RSpec.describe 'Market Index' do
       create_list(:market, 5)
       get api_v1_markets_path
       expect(response).to be_successful
+
+      markets = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(markets.count).to eq(5)
+
+      markets.each do |market|
+        expect(market[:attributes]).to have_key(:name)
+        expect(market[:attributes][:name]).to be_a(String)
+        
+        expect(market[:attributes]).to have_key(:address)
+        expect(market[:attributes][:address]).to be_a(String)
+
+        expect(market[:attributes]).to have_key(:site)
+        expect(market[:attributes][:site]).to be_a(String)
+
+        expect(market[:attributes]).to have_key(:description)
+        expect(market[:attributes][:description]).to be_a(String)
+
+        expect(market[:attributes]).to have_key(:fnap)
+        expect(market[:attributes][:fnap]).to be_a(String)
+
+        expect(market[:attributes]).to have_key(:snap_option)
+        expect(market[:attributes][:snap_option]).to be_a(String)
+
+        expect(market[:attributes]).to have_key(:accepted_payment)
+        expect(market[:attributes][:accepted_payment]).to be_a(String)
+
+        expect(market[:attributes]).to have_key(:longitude)
+        expect(market[:attributes][:longitude]).to be_an(Float)
+
+        expect(market[:attributes]).to have_key(:latitude)
+        expect(market[:attributes][:latitude]).to be_an(Float)
+
+      end
     end
   end
 end


### PR DESCRIPTION
This PR implements a few changes: 
It scraps use of the Ruby Geocoder gem due to rate limits and slow loading times.
It adds the rails geokit extension to the api to make Active Record haversine queries easy.
It fleshes out the market model to add methods to query the database. The most useful method will be the ::nearby_markets method which returns farmers market records by proximity to a coordinate. 
Knocks out issue #6 

Because this pulled from get_all_markets branch to stay up to date with changes, this pr will also add a market serializer and test (Thanks, @Jesse193 !)